### PR TITLE
Fix: use default cors

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -16,12 +16,8 @@ const rateLimitMiddleware = limit({
   headers: true,
 });
 
-const corsSettings = {
-  origin: 'http://localhost:5173',
-};
-
 //app.use(auth.authenticateApiKey);
-app.use(cors(corsSettings));
+app.use(cors());
 app.use(rateLimitMiddleware);
 app.use('/', express.static('metern', { index: '../index.html' }));
 app.set('trust proxy', 1);


### PR DESCRIPTION
```js
const corsSettings = {
  origin: 'http://localhost:5173',
};

//app.use(auth.authenticateApiKey);
app.use(cors(corsSettings));
```

This will block any request not from http://localhost:5173, which is unwanted. Default CORS will allow every URL. 

> "Success isn't measured by the heights you reach, but by the depths you overcome." — Aria Thompson